### PR TITLE
Feature/flux model r5d

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,18 @@ Once setup is complete, the tool can be run from any directory.
 
 ## Using spotutil
 
-**Create a spot instance** 
+###Create a spot instance
 
-`spotutil new m4.large <key_pair>`
+`spotutil new <instance_type> <key_pair>`
 
 Instance types commonly used: m4.large, m4.xlarge, m4.2xlarge, m4.4xlarge, m4.10xlarge, m4.16xlarge,
 r4.large, r4.xlarge, r4.2xlarge, r4.4xlarge, r4.8xlarge, r4.16xlarge,
 r5d.large, r5d.xlarge, r5d.2xlarge, r5d.4xlarge, r5d.8xlarge, r5d.12xlarge, r5d.16xlarge, r5d.24xlarge.
 
-For `<key_pair>` use name for any key pair registered with your AWS account. Make sure you are in posession of the private key. You will need it to SSH into the machine
+For `<key_pair>` use name for any key pair registered with your AWS account. 
+Make sure you are in possession of the private key. You will need it to SSH into the machine
+
+####Creating and Puttying into r5d instances
 
 Providing an r5d instance type automatically launches an instance configured to run the forest carbon flux model,
 including all the user data found in the launch template.
@@ -61,12 +64,25 @@ also optionally be specified if the user does not want to use the default templa
 carbon_flux_model_python3_v2 
 (https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchTemplateDetails:launchTemplateId=lt-00205de607ab6d4d9).
 
+If you create an r5d instance, you must Putty into it within the first two or three minutes after it is created.
+For unclear reasons, r5d instances block new Putty connections after a few minutes.
+(The error box says: "Network error: Software caused connection abort.")
 
-**List the active spots instances** 
+Also, when Puttying into r5d instances, supply the r5d_ec2.ppk for Connection -> SSH -> Auth -> Private Key File  
+instead of your `<username>_wri.ppk`. r5d instances require r5d_ec2.ppk instead of `<username>_wri.ppk`
+due to the launch template being used. Still use your personal key_pair in the command line
+when you create the spot instance, though; this is just a change to what is supplied to Putty. Ask David Gibbs or Erin
+Glen for this specific ppk.
+
+
+### List the active spots instances
 
 `spotutil ls`
 
-**Remove an active spot instance*
+This shows a table of all active spot instances, with columns showing the user,
+instance type, internal IP address, external IP address, and up time. 
+
+### Remove an active spot instance
 
 Multiple instances can be deleted at the same time using the username or instance type arguments. 
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,13 @@ r5d.large, r5d.xlarge, r5d.2xlarge, r5d.4xlarge, r5d.8xlarge, r5d.12xlarge, r5d.
 
 For `<key_pair>` use name for any key pair registered with your AWS account. Make sure you are in posession of the private key. You will need it to SSH into the machine
 
-Providing an r5d instance type automatically launches an instance configured to run the forest carbon flux model.
+Providing an r5d instance type automatically launches an instance configured to run the forest carbon flux model,
+including all the user data found in the launch template.
 The `--carbon-flux` flag can optionally be added to r5d instances. The `--carbon-flux` flag cannot be added to other
-instance type requests. (e.g., m4 and r4). 
+instance type requests. (e.g., m4 and r4). For flux model runs, `--launch-template` and `--launch-template-version` can
+also optionally be specified if the user does not want to use the default template or version. The current template is
+carbon_flux_model_python3_v2 
+(https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchTemplateDetails:launchTemplateId=lt-00205de607ab6d4d9).
 
 
 **List the active spots instances** 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # spotutil
 
 ## Introduction
-CLI tool to create, kill and list spot workers on AWS
+Command line tool to create, kill and list ec2 spot workers on AWS
 
-Used by GFW staff to create / manage spot instances. Default instance ID is updated frequently to point at our preferred analysis AMI, which includes GDAL, gmt, and other common OSGEO packages.
+Used by GFW staff to create / manage spot instances. 
+Default instance ID depends on the instance type created. 
+For most instance types, a generic analysis AMI, which includes GDAL and other common OSGEO packages, is used.
+For r5d instances, a specific AMI and launch template are used that are configured to run the forest carbon flux model
+(https://github.com/wri/carbon-budget).
 
 ## Requirements
-Requires a `tokens` dir with .pem file to allow fab to enter the machine, in addition to proper AWS / EC2 permissions.
+Requires a `tokens` dir with .pem file to allow fab to enter (SSH into) the machine, in addition to proper AWS / EC2 permissions.
 
 
 ## Set-up
@@ -30,28 +34,42 @@ Default output format: json
 
 ## Install spotutil
 
-`pip install git+http://github.com/wri/spotutil`
+The tool is written to be run from any directory. There are two ways to install it as a system command that can be run from anywhere.
+
+1. `pip install git+http://github.com/wri/spotutil`
+2. In the folder where spotutil is located on your computer (e.g., C:\Users\xyz\Git\spotutil): `pip install .` (requires pip)
 
 Once setup is complete, the tool can be run from any directory.
 
 ## Using spotutil
 
-**Create a spot** 
+**Create a spot instance** 
 
 `spotutil new m4.large <key_pair>`
 
-Instance types commonly used: m4.large, m4.xlarge, m4.2xlarge, m4.4xlarge, m4.10xlarge, m4.16xlarge
+Instance types commonly used: m4.large, m4.xlarge, m4.2xlarge, m4.4xlarge, m4.10xlarge, m4.16xlarge,
+r4.large, r4.xlarge, r4.2xlarge, r4.4xlarge, r4.8xlarge, r4.16xlarge,
+r5d.large, r5d.xlarge, r5d.2xlarge, r5d.4xlarge, r5d.8xlarge, r5d.12xlarge, r5d.16xlarge, r5d.24xlarge.
 
 For `<key_pair>` use name for any key pair registered with your AWS account. Make sure you are in posession of the private key. You will need it to SSH into the machine
 
-**Lists the active spots** 
+Providing an r5d instance type automatically launches an instance configured to run the forest carbon flux model.
+The `--carbon-flux` flag can optionally be added to r5d instances. The `--carbon-flux` flag cannot be added to other
+instance type requests. (e.g., m4 and r4). 
+
+
+**List the active spots instances** 
 
 `spotutil ls`
 
-**Remove an active spot**
+**Remove an active spot instance*
 
-`spotutil rm [--username][--interal_ip][--external_ip]`
+Multiple instances can be deleted at the same time using the username or instance type arguments. 
 
-Example: `spotutil rm --username sgibbes.local`
+`spotutil rm [--username][--interal_ip][--external_ip][--instance_type]`
+
+Example: `spotutil rm --username David.Gibbs`
+Example: `spotutil rm --internal_ip 192.168.80.30`
+Example: `spotutil rm --instance_type m4.2xlarge`
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 click
-boto
 boto3
 future
 prettytable

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ with open("README.md", "r") as fh:
 setup(
     name="spotutil",
     version="0.1.0",
-    author="Charlie Hofmann, Thomas Maschler",
-    author_email="thomas.maschler@wri.org",
-    description="Create an AWS Spot request. View active Spot instances",
+    author="Charlie Hofmann, Thomas Maschler, David Gibbs",
+    author_email="david.gibbs@wri.org",
+    description="Create an AWS ec2 spot request. View active spot instances. Delete active spot instances",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/wri/spotutil",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="spotutil",
-    version="0.0.2",
+    version="0.0.3",
     author="Charlie Hofmann, Thomas Maschler",
     author_email="thomas.maschler@wri.org",
     description="Create an AWS Spot request. View active Spot instances",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="spotutil",
-    version="0.0.3",
+    version="0.1.0",
     author="Charlie Hofmann, Thomas Maschler",
     author_email="thomas.maschler@wri.org",
     description="Create an AWS Spot request. View active Spot instances",

--- a/spotutil/spotutil.py
+++ b/spotutil/spotutil.py
@@ -10,11 +10,11 @@ def spotutil():
 
 
 @spotutil.command('new')
-@click.argument('instance_type')
+@click.argument('instance_type')   # r5d instances result in carbon flux model template being used
 @click.argument('key_pair')
 @click.option('--price', default=3)
 @click.option('--disk-size', default=500)
-@click.option('--ami-id', default='ami-017dc21b2db099158') #AMI for GDAL-PROCESSOR-20181109
+@click.option('--ami-id', default='ami-017dc21b2db099158') # AMI for GDAL-PROCESSOR-20181109, applies to non-r5d instances
 @click.option('--flux-model', is_flag=True)   # Denotes if a spot instance for the carbon flux model should be created
 @click.option('--launch-template', default='lt-00205de607ab6d4d9')  # ec2 launch template to use for flux model instance
 @click.option('--launch-template-version', default="5")  # version of ec2 launch template to use for flux model instance
@@ -34,6 +34,7 @@ def list_spots():
 @click.option('--username', help='The user printed when running `spotutil ls`')
 @click.option('--internal_ip', help='The internal IP')
 @click.option('--external_ip', help='The external IP')
-def remove_spot(username, internal_ip, external_ip):
-    removespot.removespot(username, internal_ip, external_ip)
+@click.option('--instance_type', help='The instance type (e.g., m4.large, r4.2xlarge, r5d.24xlarge)')
+def remove_spot(username, internal_ip, external_ip, instance_type):
+    removespot.removespot(username, internal_ip, external_ip, instance_type)
 

--- a/spotutil/spotutil.py
+++ b/spotutil/spotutil.py
@@ -13,7 +13,7 @@ def spotutil():
 @click.argument('instance_type')
 @click.argument('key_pair')
 @click.option('--price', default=3)
-@click.option('--disk_size', default=500)
+@click.option('--disk-size', default=500)
 @click.option('--ami-id', default='ami-017dc21b2db099158') #AMI for GDAL-PROCESSOR-20181109
 @click.option('--flux-model', is_flag=True)   # Denotes if a spot instance for the carbon flux model should be created
 @click.option('--launch-template', default='lt-00205de607ab6d4d9')  # ec2 launch template to use for flux model instance

--- a/spotutil/spotutil.py
+++ b/spotutil/spotutil.py
@@ -15,8 +15,13 @@ def spotutil():
 @click.option('--price', default=3)
 @click.option('--disk_size', default=500)
 @click.option('--ami-id', default='ami-017dc21b2db099158') #AMI for GDAL-PROCESSOR-20181109
-def new_spot(instance_type, key_pair, price, disk_size, ami_id):
-    newspot.newspot(instance_type, key_pair, price, disk_size, ami_id)
+@click.option('--flux-model', is_flag=True)   # Denotes if a spot instance for the carbon flux model should be created
+@click.option('--launch-template', default='lt-00205de607ab6d4d9')  # ec2 launch template to use for flux model instance
+@click.option('--launch-template-version', default="5")  # version of ec2 launch template to use for flux model instance
+def new_spot(instance_type, key_pair, price, disk_size, ami_id,
+             flux_model, launch_template, launch_template_version):
+    newspot.newspot(instance_type, key_pair, price, disk_size, ami_id,
+                    flux_model, launch_template, launch_template_version)
 
 
 @spotutil.command('ls')

--- a/spotutil/spotutil.py
+++ b/spotutil/spotutil.py
@@ -26,7 +26,7 @@ def new_spot(instance_type, key_pair, price, disk_size, ami_id,
 
 @spotutil.command('ls')
 def list_spots():
-    click.echo('Listing active Spots')
+    click.echo('Listing active spot machines')
     listspot.listspot()
 
 

--- a/spotutil/spotutil.py
+++ b/spotutil/spotutil.py
@@ -17,7 +17,7 @@ def spotutil():
 @click.option('--ami-id', default='ami-017dc21b2db099158') # AMI for GDAL-PROCESSOR-20181109, applies to non-r5d instances
 @click.option('--flux-model', is_flag=True)   # Denotes if a spot instance for the carbon flux model should be created
 @click.option('--launch-template', default='lt-00205de607ab6d4d9')  # ec2 launch template to use for flux model instance
-@click.option('--launch-template-version', default="5")  # version of ec2 launch template to use for flux model instance
+@click.option('--launch-template-version', default="16") # version of ec2 launch template to use for flux model instance
 def new_spot(instance_type, key_pair, price, disk_size, ami_id,
              flux_model, launch_template, launch_template_version):
     newspot.newspot(instance_type, key_pair, price, disk_size, ami_id,

--- a/spotutil/utilities/listspot.py
+++ b/spotutil/utilities/listspot.py
@@ -51,6 +51,7 @@ def listspot():
                 spot_dict['external_ip'] = external_ip
                 spot_dict['user'] = user
                 spot_dict['id'] = r.id
+                spot_dict['instance_type'] = instance_type
                 spot_info_list.append(spot_dict)
 
         print(table)

--- a/spotutil/utilities/newspot.py
+++ b/spotutil/utilities/newspot.py
@@ -1,9 +1,10 @@
 from spotutil.utilities import spot_instance
 
 
-def newspot(instance_type, key_pair, price, disk_size, ami_id):
+def newspot(instance_type, key_pair, price, disk_size, ami_id, flux_model, launch_template, launch_template_version):
 
-    instance = spot_instance.Instance(instance_type, key_pair, price, disk_size, ami_id)
+    instance = spot_instance.Instance(instance_type, key_pair, price, disk_size, ami_id,
+                                      flux_model, launch_template, launch_template_version)
 
     instance.start()
 

--- a/spotutil/utilities/removespot.py
+++ b/spotutil/utilities/removespot.py
@@ -3,7 +3,7 @@ from spotutil.utilities.listspot import listspot
 import boto3
 
 
-def removespot(username=None, internal_ip=None, external_ip=None):
+def removespot(username=None, internal_ip=None, external_ip=None, instance_type=None):
 
     client = boto3.client('ec2', 'us-east-1')
 
@@ -11,7 +11,7 @@ def removespot(username=None, internal_ip=None, external_ip=None):
     table, spot_list = listspot()
 
     # turn inputs in a dict, can then find matching input
-    inputs = {'user': username, 'internal_ip': internal_ip, 'external_ip': external_ip}
+    inputs = {'user': username, 'internal_ip': internal_ip, 'external_ip': external_ip, 'instance_type': instance_type}
 
     inputs = dict((k, v) for k, v in inputs.items() if v is not None)
 
@@ -23,7 +23,7 @@ def removespot(username=None, internal_ip=None, external_ip=None):
 
         if request[spot_filter_key] == spot_filter_val:
             found_match = True
-            print("canceling this spot request: {}".format(request))
+            print("Canceling this spot request: {}".format(request))
 
             instance_id = request['instance_id']
 
@@ -31,7 +31,7 @@ def removespot(username=None, internal_ip=None, external_ip=None):
 
             response = client.cancel_spot_instance_requests(SpotInstanceRequestIds=[request['id']])
             status = response[u'CancelledSpotInstanceRequests'][0]['State']
-            print("Status of request to Cancel Spot: {}".format(status))
+            print("Status of request to cancel spot: {}".format(status))
 
     if not found_match:
         print("WARNING: There are no active spot instances with {0} of {1}".format(spot_filter_key, spot_filter_val))

--- a/spotutil/utilities/spot_instance.py
+++ b/spotutil/utilities/spot_instance.py
@@ -198,11 +198,8 @@ class Instance(object):
 
             if state == 'active':
                 running = True
+                self._tag_request()
 
-
-            #     self.spot_request.add_tag('User', self.user)
-            #     self.spot_request.add_tag('Project', "Global Forest Watch")
-            #     self.spot_request.add_tag('Job', "Spotutil")
 
     @retry(wait_fixed=2000, stop_max_attempt_number=10)
     def wait_for_instance(self):
@@ -276,3 +273,20 @@ class Instance(object):
             except Exception as e: 
                 print("something's wrong with %s:%d. Exception is %s" % (self.ssh_ip, port, e))
                 time.sleep(10)
+
+    def _tag_request(self):
+
+        if self.flux_model:
+
+            tags = [
+                {"Key": "User", "Value": self.user},
+                {"Key": "Project", "Value": self.project},
+                {"Key": "Job", "Value": self.job},
+            ]
+            boto3_ec2_conn.create_tags(Resources=[self.request_id], Tags=tags)
+
+        else:
+
+            self.spot_request.add_tag('User', self.user)
+            self.spot_request.add_tag('Project', self.project)
+            self.spot_request.add_tag('Job', self.job)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

1. Could create r4 instances but not Putty into them.
2. Could not create or Putty into r5d instances, which are used for the forest carbon flux model.
3. Could not delete all instance of the same instance type. 
4. Launch the instance in the cheapest region.

## What is the new behavior?

1. Can now create and Putty into m4 and r4 instances.
2. Can now create and Putty into r5d instances, based on the flux model launch template. So, flux model spot machines can now be launched from spotutil. 
3. Can now delete all instances of the same instance type using `spotutil rm --instance_type <instance_type>`
4. Still launches the instance in the cheapest region.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

David and Erin both tested Puttying into m4.large, m4.16xlarge, r4.large, r4.16xlarge, r5d.large, and r5d.24xlarge instances. Storage is displayed correctly in all cases: EBS in m4 and r4 and SSD volume(s) for r5d. Can also enter Docker container and run flux model in r5d instances. 
Readme updated accordingly. 